### PR TITLE
Use 'axes' metadata to pick channel_axis

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -63,9 +63,14 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                     if "colormap" in metadata:
                         del metadata["colormap"]
 
+                elif "axes" in metadata and "c" in metadata["axes"]:
+                    metadata["channel_axis"] = metadata["axes"].index("c")
+                    del metadata["axes"]
                 elif shape[CHANNEL_DIMENSION] > 1:
+                    # versions of ome-zarr-py before v0.3 support
                     metadata["channel_axis"] = CHANNEL_DIMENSION
                 else:
+                    # single channel image, so metadata just needs single items (not lists)
                     for x in ("name", "visible", "contrast_limits", "colormap"):
                         if x in metadata:
                             try:

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -25,7 +25,8 @@ except ImportError:
 
 LOGGER = logging.getLogger("napari_ome_zarr.reader")
 
-METADATA_KEYS = ("name", "visible", "contrast_limits", "colormap")
+METADATA_KEYS = ("name", "visible", "contrast_limits", "colormap",
+                 "metadata", "properties")
 
 @napari_hook_implementation
 def napari_get_reader(path: PathLike) -> Optional[ReaderFunction]:
@@ -61,6 +62,9 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                 layer_type: str = "image"
                 if node.load(Label):
                     layer_type = "labels"
+                    for x in METADATA_KEYS:
+                        if x in node.metadata:
+                            metadata[x] = node.metadata[x]
                 else:
                     channel_axis = None
                     if "axes" in node.metadata:
@@ -75,7 +79,8 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         # multi-channel; Copy known metadata values
                         metadata["channel_axis"] = channel_axis
                         for x in METADATA_KEYS:
-                            metadata[x] = node.metadata[x]
+                            if x in node.metadata:
+                                metadata[x] = node.metadata[x]
                     else:
                         # single channel image, so metadata just needs single items (not lists)
                         for x in METADATA_KEYS:


### PR DESCRIPTION
Reading OME_NGFF v0.3 data with https://github.com/ome/ome-zarr-py/pull/89 fails since we no-longer have 5 dimensions and the channel_axis isn't hard-coded.

This PR dynamically sets the `channel_axis` based on the `axes` metadata.

cc @joshmoore @constantinpape 
