### PR TITLE
Wrap colormap in vispy object

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -8,6 +8,8 @@ import logging
 import warnings
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
+from vispy.color import Colormap
+
 from ome_zarr.data import CHANNEL_DIMENSION
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Label, Node, Reader
@@ -72,6 +74,12 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                                 metadata[x] = metadata[x][0]
                             except Exception:
                                 del metadata[x]
+
+                # Handle the removal of vispy requirement from ome-zarr-py
+                cms = metadata.get("colormap", [])
+                for idx, cm in enumerate(cms):
+                    if not isinstance(cm, Colormap):
+                        cms[idx] = Colormap(cm)
 
                 rv: LayerData = (data, metadata, layer_type)
                 LOGGER.debug(f"Transformed: {rv}")


### PR DESCRIPTION
see: https://github.com/ome/ome-zarr-py/pull/91/commits/d79c39361b882a35d88a6d36e9587f0266a25213

Optionally wraps colormaps to support versions of ome-zarr-py _before_ PR 91 as well as after.

cc: @will-moore 