### PR TITLE
Labels properties are a dict of lists

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     # you can remove these if you don't use them
     napari
     magicgui
+    pooch
     pytest-qt
     qtpy
     pyqt5


### PR DESCRIPTION
Fixes #6.

This updates `napari-ome-zarr` to transform label properties into the format that napari is now expecting, using `index` as the label ID as described at https://forum.image.sc/t/napari-labels-layer-properties/57649

e.g.
```
    {
        "index": [1381342, 1381343...]
        "key1": [1381342, 1381343...],
        "key2": [1682567, 1682567...]
    }
```

To test, using data exported from `omero-cli-zarr` at PR: https://github.com/ome/omero-cli-zarr/pull/82/

```
napari https://minio-dev.openmicroscopy.org/idr/v0.3/idr0062-blin-nuclearsegmentation/6001247.zarr
```

Mousing over a label should show associated values in the footer:

![Screenshot 2021-09-20 at 14 06 01](https://user-images.githubusercontent.com/900055/134007292-b3762523-d404-4937-a012-927869edfd69.png)
