### PR TITLE
Fix failure to create Colormap for single-channel data

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -111,6 +111,12 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         # versions of ome-zarr-py before v0.3 support
                         channel_axis = CHANNEL_DIMENSION
 
+                    # Handle the removal of vispy requirement from ome-zarr-py
+                    cms = node.metadata.get("colormap", [])
+                    for idx, cm in enumerate(cms):
+                        if not isinstance(cm, Colormap):
+                            cms[idx] = Colormap(cm)
+
                     if channel_axis is not None:
                         # multi-channel; Copy known metadata values
                         metadata["channel_axis"] = channel_axis
@@ -125,12 +131,6 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                                     metadata[x] = node.metadata[x][0]
                                 except Exception:
                                     pass
-
-                # Handle the removal of vispy requirement from ome-zarr-py
-                cms = metadata.get("colormap", [])
-                for idx, cm in enumerate(cms):
-                    if not isinstance(cm, Colormap):
-                        cms[idx] = Colormap(cm)
 
                 properties = transform_properties(node.metadata.get("properties"))
                 if properties is not None:


### PR DESCRIPTION
This fixes the opening of images without a channel dimension that have `color` info in an `omero` metadata.

For images without a channel dimension, we convert
```
colormaps = [
   [[r,g,b], [r2,g2,b2]]
]
```
into
```
colormaps = [[r,g,b], [r2,g2,b2]]
```
but this is not handled by the subsequent code that tries to create `ColorMap`s. So it tries to create a `ColorMap` from `[r,g,b]` instead of `[[r,g,b], [r2,g2,b2]]`.
To fix this, simply move the `ColorMap` creation code before the unwrapping of the list for single-channel images.

Since we only find this bug with v0.3 data that don't have a `c` dimension, it is not found on any public data.

To test, NB: needs https://github.com/ome/ome-zarr-py/pull/114 to create 2D sample image:

```
$ ome_zarr create coinsimg
$ napari coinsimg
```

![Screenshot 2021-09-29 at 09 12 05](https://user-images.githubusercontent.com/900055/135229393-0dfe542d-b26f-4a21-b999-ea5d24aa36cd.png)

