### PR TITLE
Squeeze channel axis for labels

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -8,6 +8,7 @@ import logging
 import warnings
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
+import numpy as np
 from vispy.color import Colormap
 
 from ome_zarr.data import CHANNEL_DIMENSION
@@ -101,6 +102,9 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                     for x in METADATA_KEYS:
                         if x in node.metadata:
                             metadata[x] = node.metadata[x]
+                    if "axes" in node.metadata and "c" in node.metadata["axes"]:
+                        c_index = node.metadata["axes"].index("c")
+                        data = [np.squeeze(level, axis=c_index) for level in node.data]
                 else:
                     channel_axis = None
                     if "axes" in node.metadata:


### PR DESCRIPTION
Corresponding to work on https://github.com/ome/omero-cli-zarr/pull/82...

It seems that to display labels correctly alongside image data that is split across multiple channels (where `channel_index` is set), the labels should not include a channels dimension.

In this PR, the channel dimension is "squeezed" (removed). NB: this is only possible if the size_c is 1.

TODO: look at splitting multi-channel labels into separate labels layers.