### PR TITLE
require ome-zarr>=0.2.0 in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
     napari-plugin-engine>=0.1.4
-    ome-zarr>=0.0.22
+    ome-zarr>=0.2.0
     numpy
 
 


### PR DESCRIPTION
Bump to require latest ome-zarr-py 0.2.0 which supports less than 5D writing.
cc @sbesson 