### PR TITLE
colormap renamed to color

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -28,7 +28,7 @@ except ImportError:
 
 LOGGER = logging.getLogger("napari_ome_zarr.reader")
 
-METADATA_KEYS = ("name", "visible", "contrast_limits", "colormap",
+METADATA_KEYS = ("name", "visible", "contrast_limits", "color",
                  "metadata")
 
 @napari_hook_implementation

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -28,8 +28,9 @@ except ImportError:
 
 LOGGER = logging.getLogger("napari_ome_zarr.reader")
 
-METADATA_KEYS = ("name", "visible", "contrast_limits", "color",
-                 "metadata")
+# NB: color for labels, colormap for images
+METADATA_KEYS = ("name", "visible", "contrast_limits", "colormap",
+                 "color", "metadata")
 
 @napari_hook_implementation
 def napari_get_reader(path: PathLike) -> Optional[ReaderFunction]:


### PR DESCRIPTION
Colours associated with labels should be named with the `color` key (see https://napari.org/api/stable/napari.Viewer.html#napari.Viewer.add_labels)

To test (with this PR and latest release of `ome-zarr-py`):

```
$ ome_zarr create coins
$ napari coins
```

With this PR, the `color mode` of the `coins` labels layer should be `direct` and the labels will display the color that corresponds to the values in `coins/labels/coins/.zattrs` (which are randomly generated at creation time).

![Screenshot 2021-10-20 at 17 23 52](https://user-images.githubusercontent.com/900055/138133153-fb8ab761-c655-48ea-9f75-e5762bcdca35.png)

(without this PR, the `color mode` is `auto`, and if you choose `direct`, the labels will be grey).

EDIT: Also need to check that channel colours are still displayed correctly. E.g. this image should have blue and yellow channels:
```
$ napari https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001246.zarr
```