### PR TITLE
moves plugin citation info to citation.cff file

### DIFF
--- a/.napari/DESCRIPTION.md
+++ b/.napari/DESCRIPTION.md
@@ -1,7 +1,7 @@
 # Description
 
 This plugin provides a reader for zarr backed OME-NGFF images in napari. The reader
-will inspect the `.zattrs` metadata provided and pass any relevant metadata, including channel, scale and colormap metadata. 
+will inspect the `.zattrs` metadata provided and pass any relevant metadata, including channel, scale and colormap metadata.
 
 ![Opening an ome-zarr image in napari](https://i.imgur.com/tf9IqRA.gif)
 
@@ -14,8 +14,8 @@ multi-resolution images stored in Zarr filesets (according to the [OME zarr spec
 without needing an intricate understanding of zarr, or the spec itself.
 
 This plugin supports reading all images recognised as ome-zarr, namely, containing
-well-formed `.zattrs` and `.zgroup` files, as well as the appropriate directory 
-hierarchy as described in the [spec](https://ngff.openmicroscopy.org/latest/). 
+well-formed `.zattrs` and `.zgroup` files, as well as the appropriate directory
+hierarchy as described in the [spec](https://ngff.openmicroscopy.org/latest/).
 The image metadata from OMERO will be used to set channel names, colormaps and rendering settings in napari.
 
 # Quickstart
@@ -45,15 +45,15 @@ the metadata:
 $ napari '/tmp/6001240.zarr/0'
 ```
 
-If an image group contains labels, they will also be opened, and added as a 
+If an image group contains labels, they will also be opened, and added as a
 separate layer in napari.
 
-When the labels group metadata additionally contains `"rgba"` and `"properties"` keys, 
-the labels will be given appropriate colors and the properties will be displayed 
+When the labels group metadata additionally contains `"rgba"` and `"properties"` keys,
+the labels will be given appropriate colors and the properties will be displayed
 in the status bar.
 
 Working with ome-zarr images can be more convenient using the command-line interface
-and utility functions of our associated library `ome-zarr`. For more information 
+and utility functions of our associated library `ome-zarr`. For more information
 please see the [package documentation](https://pypi.org/project/ome-zarr/) for `ome-zarr`.
 
 # Getting Help
@@ -64,12 +64,6 @@ raise an issue on our repository at https://github.com/ome/napari-ome-zarr.
 If you would like assistance with using the plugin, or converting images to
 ome-zarr format, please reach out on [image.sc](https://forum.image.sc/).
 
-# How to Cite
-
-## To cite OME-NGFF:
+# How to Cite OME-NGFF:
 
 [Next-generation file format (NGFF) specifications for storing bioimaging data in the cloud](https://ngff.openmicroscopy.org/0.1/). J. Moore, et al. Editors. Open Microscopy Environment Consortium, 20 November 2020. This edition of the specification is https://ngff.openmicroscopy.org/0.1/. The latest edition is available at https://ngff.openmicroscopy.org/latest/. ([doi:10.5281/zenodo.4282107](https://doi.org/10.5281/zenodo.4282107))
-
-## To cite this plugin:
-
-[ome-zarr-py: Experimental implementation of next-generation file format (NGFF) specifications for storing bioimaging data in the cloud.](https://doi.org/10.5281/zenodo.4113931) OME; et al. 06 October 2020. URL: https://doi.org/10.5281/zenodo.4113931

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,32 @@
+# YAML 1.2
+# Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
+cff-version: 1.0.3
+message: If you use this software, please cite it using these metadata.
+# FIXME title as repository name might not be the best name, please make human readable
+title: 'ome-zarr-py: Experimental implementation of next-generation file format (NGFF) specifications for storing bioimaging data in the cloud.'
+doi: 10.5281/zenodo.4113931
+# FIXME splitting of full names is error prone, please check if given/family name are correct
+authors:
+- given-names: Josh
+  family-names: Moore
+  affiliation: '@openmicroscopy'
+- given-names: Will
+  family-names: Moore
+  affiliation: '@openmicroscopy'
+- given-names: Jean-Marie
+  family-names: Burel
+- given-names: Simon
+  family-names: Li
+- given-names: Eric
+  family-names: Perlman
+  affiliation: Yikes LLC
+- given-names: Juan
+  family-names: Nunez-Iglesias
+  affiliation: Monash Micro Imaging, Monash University
+- given-names: Talley
+  family-names: Lambert
+  affiliation: Harvard University
+- given-names: Heath
+  family-names: Patterson
+  affiliation: Vanderbilt University
+repository-code: https://github.com/ome/ome-zarr-py

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,31 +2,17 @@
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
 cff-version: 1.0.3
 message: If you use this software, please cite it using these metadata.
-# FIXME title as repository name might not be the best name, please make human readable
-title: 'ome-zarr-py: Experimental implementation of next-generation file format (NGFF) specifications for storing bioimaging data in the cloud.'
-doi: 10.5281/zenodo.4113931
-# FIXME splitting of full names is error prone, please check if given/family name are correct
-authors:
+title: 'napari-ome-zarr'
+doi: 10.5281/zenodo.5620852
 - given-names: Josh
   family-names: Moore
   affiliation: '@openmicroscopy'
 - given-names: Will
   family-names: Moore
   affiliation: '@openmicroscopy'
-- given-names: Jean-Marie
-  family-names: Burel
-- given-names: Simon
-  family-names: Li
-- given-names: Eric
-  family-names: Perlman
-  affiliation: Yikes LLC
-- given-names: Juan
-  family-names: Nunez-Iglesias
-  affiliation: Monash Micro Imaging, Monash University
-- given-names: Talley
-  family-names: Lambert
-  affiliation: Harvard University
-- given-names: Heath
-  family-names: Patterson
-  affiliation: Vanderbilt University
-repository-code: https://github.com/ome/ome-zarr-py
+- given-names: Sébastien
+  family-names: Besson
+  affiliation: University of Dundee
+- given-names: Draga
+  family-names: Doncila Pop
+repository-code: https://github.com/ome/napari-ome-zarr


### PR DESCRIPTION
Hi @joshmoore and all!!

We are about to launch a new feature on the napari hub, [adding support for plugin devs to specify citation info](https://github.com/chanzuckerberg/napari-hub/issues/238) using a standard [CITATION.cff file](https://citation-file-format.github.io/)

This feature will look something like the following on your plugin page, under your description...

![image](https://user-images.githubusercontent.com/1245615/139352130-165265ec-d9b2-4516-a543-26e62e1612e4.png)

This PR removes the citation info in your plugin description & implements a CITATION.cff file generated from your zenodo DOI using `doi2cff`. As soon as you merge it, Github will add a "how to cite" section on the right hand side of your repo and we'll be able to do QA on this feature to make sure it works before we launch next week.

Let us know if you have any feedback!!

cc @kne42