### PR TITLE
v0.4 axes transforms

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -127,6 +127,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         channel_axis = ch_types.index("channel")
                 except:
                     LOGGER.error("Error reading axes: Please update ome-zarr")
+                    raise
 
                 transform_scale(node.metadata, metadata, channel_axis, data[0].shape)
                 # If layer has no scale info, try apply scale from first layer
@@ -142,7 +143,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                     if channel_axis is not None:
                         data = [np.squeeze(level, axis=channel_axis) for level in node.data]
                 else:
-                    LOGGER.debug("napari-ome-zarr: node.metadata: %s" % node.metadata)
+                    LOGGER.debug("node.metadata: %s" % node.metadata)
                     # Handle the removal of vispy requirement from ome-zarr-py
                     cms = node.metadata.get("colormap", [])
                     for idx, cm in enumerate(cms):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
     napari-plugin-engine>=0.1.4
-    ome-zarr>=0.2.0
+    ome-zarr==0.3a1
     numpy
 
 


### PR DESCRIPTION
WIP:

Test `napari https://minio-dev.openmicroscopy.org/idr/v0.4/2022-01-05/idr0062/6001240.zarr`.
To show scale-bar, open the napari terminal and (on latest napari):
```
viewer.scale_bar.visible = True
```
(This *was previously* `viewer.scale_bar_visible` https://github.com/napari/napari/pull/1720)

This PR requires https://pypi.org/project/ome-zarr/0.3a1/

To do:
 - [x] handle axes in v0.4 format
 - [x] handle transform scale to set pixel sizes 
 - [ ] affine transform ?!?

Not sure yet how to convert affine transform in the spec into what napari is expecting? https://napari.org/api/stable/napari.Viewer.html#napari.Viewer.add_image

```
- scale (tuple of float or list) – Scale factors for the layer. If a list then must be a list of tuples of float with the same length as the axis that is being expanded as channels.

- affine (n-D array or napari.utils.transforms.Affine) – (N+1, N+1) affine transformation matrix in homogeneous coordinates. The first (N, N) entries correspond to a linear transform and the final column is a length N translation vector and a 1 or a napari Affine transform object. Applied as an extra transform on top of the provided scale, rotate, and shear values.
```