### PR TITLE
coordinateTransformations scale list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
     napari-plugin-engine>=0.1.4
-    ome-zarr==0.3a1
+    ome-zarr>=0.3a2
     numpy
     vispy
 


### PR DESCRIPTION
This uses the updated `coordinateTransformations` format for `scale` and `translate`, implemented in https://github.com/ome/ome-zarr-py/pull/162

To test, using idr0101 where we have smaller images "cropped" from larger images, we can overlay them
using the `translate` transformation. I have manually edited the `13457537.zarr/.zattrs` and the `/labels/0/.zattrs` to add translate, based on the rectangle 'crop' ROIs on the larger image.

First, open the larger image in napari:
```
$ napari https://minio-dev.openmicroscopy.org/idr/v0.4/2022-02-03/idr0101/13457227.zarr
```
Then, in `napari` terminal, open the smaller one (also contains labels):
```
viewer.open("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr", plugin="napari-ome-zarr")
```

![Screenshot 2022-02-04 at 11 47 47](https://user-images.githubusercontent.com/900055/152524782-367a7dfb-b045-407b-9304-0f771aef8e8e.png)


Also:
```
$ napari https://minio-dev.openmicroscopy.org/idr/v0.4/2022-02-03/idr0062/6001240.zarr
```

