### PR TITLE
Add minimal napari requirement for the plugin to be discovered

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/napari_ome_zarr/_tests/test_reader.py
+++ b/napari_ome_zarr/_tests/test_reader.py
@@ -7,13 +7,6 @@ from ome_zarr.data import astronaut, create_zarr
 from napari_ome_zarr._reader import napari_get_reader
 
 
-@pytest.fixture(autouse=True, scope="session")
-def load_napari_conftest(pytestconfig):
-    from napari import conftest
-
-    pytestconfig.pluginmanager.register(conftest, "napari-conftest")
-
-
 class TestNapari:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):

--- a/napari_ome_zarr/napari.yaml
+++ b/napari_ome_zarr/napari.yaml
@@ -10,4 +10,5 @@ contributions:
     - command: napari-ome-zarr.get_reader
       filename_patterns:
         - "*.zarr"
+        - "*.zarr/"
       accepts_directories: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,9 @@ classifiers =
 	Topic :: Software Development :: Testing
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Operating System :: OS Independent
 	License :: OSI Approved :: BSD License
 project_urls =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
 	ome-zarr>=0.3.0
 	numpy
 	vispy
+	napari>=0.4.13
 include_package_data = True
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39}-{linux,macos,windows}
+envlist = py{37,38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 PLATFORM =

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39,310}-{linux,macos,windows}
+envlist = py{38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
See https://github.com/ome/napari-ome-zarr/pull/42#issuecomment-1165932251

While this plugin does not directly consume `napari` APIs, the plugin engine mechanism requires a minimal version of upstream `napari`. This proposes to use the standard Python packaging markup to capture this minimal requirement.

Proposed tag: `0.5.1`