### PR TITLE
Allow any filepath that *contains* zarr

### DIFF
--- a/napari_ome_zarr/napari.yaml
+++ b/napari_ome_zarr/napari.yaml
@@ -10,5 +10,5 @@ contributions:
     - command: napari-ome-zarr.get_reader
       filename_patterns:
         - "*.zarr"
-        - "*.zarr/"
+        - "*.zarr*"
       accepts_directories: true


### PR DESCRIPTION

Currently, file paths recognised by `napari-ome-zarr` must end in `.zarr` or `.zarr/`.
However, this doesn't support viewing of HCS Wells or Images.

As suggested by [DragaDoncila](https://github.com/DragaDoncila) at https://github.com/ome/napari-ome-zarr/pull/55#issuecomment-1171362735, this PR allows the path to contain `.zarr` at any point

To test, open a Well and Image from a Plate. NB: opening the plate itself `.zarr/` still works:

```
# Well (screenshot)
$ napari --plugin napari-ome-zarr https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr/A/1/

# Image:
$ napari --plugin napari-ome-zarr https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr/A/1/0/

# Plate:
$ napari --plugin napari-ome-zarr https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr/
```

Without this PR, opening an unrecognised path as above gave:
```
  File "/Users/wmoore/opt/anaconda3/envs/napari-env/lib/python3.9/site-packages/napari/plugins/io.py", line 86, in read_data_with_plugins
    raise ValueError(
ValueError: There is no registered plugin named 'napari-ome-zarr'.
Names of plugins offering readers are: {'ome-types', 'builtins'}
```

![Screenshot 2022-06-30 at 17 23 51](https://user-images.githubusercontent.com/900055/176730805-f7dad505-361f-4f17-b6b9-194fe9a58dfb.png)

cc @sbesson 
