### PR TITLE
Pre commit ci update config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
         args: [--target-version=py36]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.2
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args:
@@ -45,7 +45,7 @@ repos:
           - --autofix
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -106,10 +106,10 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
             data: List[Any] = node.data
             metadata: Dict[str, Any] = {}
             if data is None or len(data) < 1:
-                LOGGER.debug(f"skipping non-data {node}")
+                LOGGER.debug("skipping non-data %s", node)
             else:
-                LOGGER.debug(f"transforming {node}")
-                LOGGER.debug("node.metadata: %s" % node.metadata)
+                LOGGER.debug("transforming %s", node)
+                LOGGER.debug("node.metadata: %s", node.metadata)
 
                 layer_type: str = "image"
                 channel_axis = None
@@ -160,7 +160,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                     metadata["properties"] = properties
 
                 rv: LayerData = (data, metadata, layer_type)
-                LOGGER.debug(f"Transformed: {rv}")
+                LOGGER.debug("Transformed: %s", rv)
                 results.append(rv)
 
         return results


### PR DESCRIPTION
Replaces https://github.com/ome/napari-ome-zarr/pull/65

updates:

- [github.com/psf/black: 22.6.0 → 22.8.0](https://github.com/psf/black/compare/22.6.0...22.8.0)
- [github.com/asottile/pyupgrade: v2.37.2 → v2.37.3](https://github.com/asottile/pyupgrade/compare/v2.37.2...v2.37.3)
- [github.com/PyCQA/flake8: 4.0.1 → 5.0.4](https://github.com/PyCQA/flake8/compare/4.0.1...5.0.4)

includes commit from https://github.com/ome/napari-ome-zarr/pull/65#issuecomment-1209093360 to go green.