### PR TITLE
Remove usage of twine

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -84,13 +84,9 @@ jobs:
           python-version: "3.x"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          git tag
+          python -m pip install --upgrade wheel
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This uses the same strategy than the one used in other repositories publishing Python packages