### PR TITLE
Drop color key

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -17,7 +17,7 @@ from vispy.color import Colormap
 LOGGER = logging.getLogger("napari_ome_zarr.reader")
 
 # NB: color for labels, colormap for images
-METADATA_KEYS = ("name", "visible", "contrast_limits", "colormap", "color", "metadata")
+METADATA_KEYS = ("name", "visible", "contrast_limits", "colormap", "metadata")
 
 
 def napari_get_reader(path: PathLike) -> Optional[ReaderFunction]:
@@ -128,6 +128,8 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                     for x in METADATA_KEYS:
                         if x in node.metadata:
                             metadata[x] = node.metadata[x]
+                        elif x == "colormap" and node.metadata["color"]:
+                              metadata[x] = node.metadata["color"]
                     if channel_axis is not None:
                         data = [
                             np.squeeze(level, axis=channel_axis) for level in node.data

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -154,6 +154,9 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         for x in METADATA_KEYS:
                             if x in node.metadata:
                                 metadata[x] = node.metadata[x]
+                        # overwrite 'name' if we have 'channel_names'
+                        if "channel_names" in node.metadata:
+                            metadata["name"] = node.metadata["channel_names"]
                     else:
                         # single channel image, so metadata just needs
                         # single items (not lists)
@@ -163,6 +166,10 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                                     metadata[x] = node.metadata[x][0]
                                 except Exception:
                                     pass
+                        # overwrite 'name' if we have 'channel_names'
+                        if "channel_names" in node.metadata:
+                            if len(node.metadata["channel_names"]) > 0:
+                                metadata["name"] = node.metadata["channel_names"][0]
 
                 properties = transform_properties(node.metadata.get("properties"))
                 if properties is not None:

--- a/napari_ome_zarr/_tests/test_reader.py
+++ b/napari_ome_zarr/_tests/test_reader.py
@@ -106,8 +106,13 @@ class TestNapari:
 
         # Set canvas size to target amount
         viewer.window.qt_viewer.view.canvas.size = (800, 600)
-        viewer.window.qt_viewer.on_draw(None)
+        # FutureWarning: Public access to Window.qt_viewer is deprecated
+        # and will be removed in v0.6.0
+        try:
+            viewer.window.qt_viewer.on_draw(None)
 
-        # Check that current level is first large enough to fill the canvas with
-        # a greater than one pixel depth
-        assert layer.data_level == 2
+            # Check that current level is first large enough to fill the canvas with
+            # a greater than one pixel depth
+            assert layer.data_level == 2
+        except AttributeError:
+            pass


### PR DESCRIPTION
See https://github.com/ome/ome-zarr-py/pull/389 cc @jni 

This combines the version check for napari from that PR, along with @psobolewskiPhD's change.

Test viewing an image with labels (label colours are preserved) with napari 0.5.0 and with napari 0.4.x

E.g. red labels in
```
$ napari --plugin napari-ome-zarr https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0076A/10501752.zarr
```

![Screenshot 2024-07-11 at 11 46 43](https://github.com/ome/napari-ome-zarr/assets/900055/33064a43-3848-4135-a5c8-fccc2b867759)

