### PR TITLE
Exclude bad version of ome-zarr

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
-	ome-zarr>=0.3.0
+	ome-zarr>=0.3.0,!=0.8.3
 	numpy
 	vispy
 	napari>=0.4.13


### PR DESCRIPTION
See https://github.com/ome/napari-ome-zarr/issues/108. It looks like version 0.9 of `ome-zarr-py` fixed the issues, but worth excluding the bad version anyway. Fixes https://github.com/ome/napari-ome-zarr/issues/108