### PR TITLE
Use build instead of sdist

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -86,8 +86,8 @@ jobs:
           python-version: "3.x"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade wheel setuptools setuptools_scm
-          python setup.py sdist bdist_wheel
+          python -mpip install build
+          python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.3.0
         with:


### PR DESCRIPTION
`sdist` produces a package name containing with `-` instead of `_`, triggering a deprecation warning (see [PEP 625](https://peps.python.org/pep-0625/)).