### PR TITLE
Action update

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -84,6 +84,6 @@ jobs:
           python -m pip install --upgrade wheel setuptools setuptools_scm
           python setup.py sdist bdist_wheel
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.4
+        uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -84,6 +84,6 @@ jobs:
           python -m pip install --upgrade wheel setuptools setuptools_scm
           python setup.py sdist bdist_wheel
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.0
+        uses: pypa/gh-action-pypi-publish@v1.8.4
         with:
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Bump pypa/gh-action-pypi-publish to 1.8.14
This matches the update done in other Python repositories