### PR TITLE
Remove ome-zarr from dependencies in pyproject.toml. Replace with zarr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "ome-zarr>=0.13.0",
     "napari>=0.4.0",
+    "zarr>=3.1.5",
 ]
 
 [project.urls]


### PR DESCRIPTION
I realised when reviewing https://github.com/conda-forge/napari-ome-zarr-feedstock/pull/15
that I hadn't actually removed `ome-zarr` as a dependency (should have done that in #123)