### PR TITLE
fix: add entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "napari-ome-zarr"
 description = "A reader for zarr backed OME-Zarr images."
-dynamic = ["version", "entry-points"]
+dynamic = ["version"]
 license = "BSD-3-Clause"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,6 +23,9 @@ dependencies = [
     "ome-zarr>=0.13.0",
     "napari>=0.4.0",
 ]
+
+[project.entry-points."napari.manifest"]
+napari-ome-zarr = "napari_ome_zarr:napari.yaml"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/ome/napari-ome-zarr/issues"


### PR DESCRIPTION
@will-moore I had trouble using the latest version of the plugin and also the code suggested by @hinderling at #149 . This fixed it for me.

Environment info:

```
napari: 0.7.0
Platform: Windows-11-10.0.26200-SP0
Python: 3.13.12 (main, Mar 24 2026, 22:56:40) [MSC v.1944 64 bit (AMD64)]
Qt: 6.11.0
PyQt6: 6.11.0
NumPy: 2.4.6
SciPy: 1.17.1
Dask: 2026.3.0
VisPy: 0.16.2
magicgui: 0.10.2
superqt: 0.8.2
in-n-out: 0.2.1
app-model: 0.5.1
psygnal: 0.15.1
npe2: 0.8.2
pydantic: 2.13.4

OpenGL:
- PyOpenGL: 3.1.10
- GL version: 4.6.0 - Build 32.0.101.8508
- MAX_TEXTURE_SIZE: np.int32(16384)
- GL_MAX_3D_TEXTURE_SIZE: 2048

Screens:
- screen 1: resolution 2560x1440, scale 1.0
- screen 2: resolution 1920x1080, scale 1.0

Optional:
- numba not installed
- triangle not installed
- napari-plugin-manager not installed
- bermuda not installed
- PartSegCore not installed

Experimental Settings:
- Async: True
- Autoswap buffers: False
- Triangulation backend: Fastest available

Settings path:
- C:\Users\johan\AppData\Local\napari\.venv_48fef7d81aa664cf00c5919054ddf55068e8c760\settings.yaml

Launch command:
- C:\Users\johan\Documents\GitHub\napari-ome-zarr\.venv\Scripts\napari

Plugins:
- napari: 0.7.0 (88 contributions)
- napari-console: 0.1.4 (0 contributions)
- napari-ome-zarr: 0.8.1.dev0+g40bc4a47b.d20260522 (2 contributions)
- napari-svg: 0.2.1 (2 contributions)

```