### PR TITLE
WIP: Add an eager reader that loads data into RAM

### DIFF
--- a/napari_ome_zarr/__init__.py
+++ b/napari_ome_zarr/__init__.py
@@ -4,4 +4,4 @@ except ImportError:
     __version__ = "unknown"
 
 
-from ._reader import napari_get_reader, napari_get_eager_reader  # noqa
+from ._reader import napari_get_eager_reader, napari_get_reader  # noqa

--- a/napari_ome_zarr/__init__.py
+++ b/napari_ome_zarr/__init__.py
@@ -4,4 +4,4 @@ except ImportError:
     __version__ = "unknown"
 
 
-from ._reader import napari_get_reader  # noqa
+from ._reader import napari_get_reader, napari_get_eager_reader  # noqa

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -50,3 +50,4 @@ def napari_get_eager_reader(path: str | list) -> Callable | None:
             return eager_result
 
         return read_ome_zarr_eager
+    return None

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -4,12 +4,12 @@ It implements the ``napari_get_reader`` hook specification, (to create a reader 
 """
 
 import warnings
-from typing import Callable
+from typing import Any, Callable
 
 import numpy as np
 import zarr
 
-from .ome_zarr_reader import read_ome_zarr
+from .ome_zarr_reader import LayerData, read_ome_zarr
 
 
 def napari_get_reader(path: str | list) -> Callable | None:
@@ -38,7 +38,7 @@ def napari_get_eager_reader(path: str | list) -> Callable | None:
     read_ome_zarr_lazy = napari_get_reader(path)
     if read_ome_zarr_lazy is not None:
 
-        def read_ome_zarr_eager(*args, **kwargs):
+        def read_ome_zarr_eager(*args: Any, **kwargs: Any) -> list[LayerData]:
             lazy_result = read_ome_zarr_lazy(*args, **kwargs)
             eager_result = []
             for data, metadata, layer_type in lazy_result:

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -37,6 +37,7 @@ def napari_get_reader(path: str | list) -> Callable | None:
 def napari_get_eager_reader(path: str | list) -> Callable | None:
     read_ome_zarr_lazy = napari_get_reader(path)
     if read_ome_zarr_lazy is not None:
+
         def read_ome_zarr_eager(*args, **kwargs):
             lazy_result = read_ome_zarr_lazy(*args, **kwargs)
             eager_result = []
@@ -47,4 +48,5 @@ def napari_get_eager_reader(path: str | list) -> Callable | None:
                     eager_data = np.asarray(data)
                 eager_result.append((eager_data, metadata, layer_type))
             return eager_result
+
         return read_ome_zarr_eager

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -6,6 +6,7 @@ It implements the ``napari_get_reader`` hook specification, (to create a reader 
 import warnings
 from typing import Callable
 
+import numpy as np
 import zarr
 
 from .ome_zarr_reader import read_ome_zarr
@@ -31,3 +32,19 @@ def napari_get_reader(path: str | list) -> Callable | None:
     if group is not None:
         return read_ome_zarr(group)
     return None
+
+
+def napari_get_eager_reader(path: str | list) -> Callable | None:
+    read_ome_zarr_lazy = napari_get_reader(path)
+    if read_ome_zarr_lazy is not None:
+        def read_ome_zarr_eager(*args, **kwargs):
+            lazy_result = read_ome_zarr_lazy(*args, **kwargs)
+            eager_result = []
+            for data, metadata, layer_type in lazy_result:
+                if type(data) == list:  # multiscales
+                    eager_data = list(map(np.asarray, data))
+                else:  # single scale
+                    eager_data = np.asarray(data)
+                eager_result.append((eager_data, metadata, layer_type))
+            return eager_result
+        return read_ome_zarr_eager

--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -42,7 +42,7 @@ def napari_get_eager_reader(path: str | list) -> Callable | None:
             lazy_result = read_ome_zarr_lazy(*args, **kwargs)
             eager_result = []
             for data, metadata, layer_type in lazy_result:
-                if type(data) == list:  # multiscales
+                if isinstance(data, list):  # multiscales
                     eager_data = list(map(np.asarray, data))
                 else:  # single scale
                     eager_data = np.asarray(data)

--- a/napari_ome_zarr/napari.yaml
+++ b/napari_ome_zarr/napari.yaml
@@ -4,10 +4,10 @@ schema_version: 0.1.0
 contributions:
   commands:
     - id: napari-ome-zarr.get_reader
-      title: Zarr Reader (Lazy)
+      title: Zarr Reader (Keep data on disk)
       python_name: napari_ome_zarr._reader:napari_get_reader
     - id: napari-ome-zarr.get_eager_reader
-      title: Zarr Reader (Eager)
+      title: Zarr Reader (Load full data to RAM)
       python_name: napari_ome_zarr._reader:napari_get_eager_reader
   readers:
     - command: napari-ome-zarr.get_reader

--- a/napari_ome_zarr/napari.yaml
+++ b/napari_ome_zarr/napari.yaml
@@ -4,10 +4,18 @@ schema_version: 0.1.0
 contributions:
   commands:
     - id: napari-ome-zarr.get_reader
-      title: Get Reader
+      title: Zarr Reader (Lazy)
       python_name: napari_ome_zarr._reader:napari_get_reader
+    - id: napari-ome-zarr.get_eager_reader
+      title: Zarr Reader (Eager)
+      python_name: napari_ome_zarr._reader:napari_get_eager_reader
   readers:
     - command: napari-ome-zarr.get_reader
+      filename_patterns:
+        - "*.zarr"
+        - "*.zarr*"
+      accepts_directories: true
+    - command: napari-ome-zarr.get_eager_reader
       filename_patterns:
         - "*.zarr"
         - "*.zarr*"


### PR DESCRIPTION
Depends on: napari/napari#4182
Depends on: napari/napari#4391

Related feature request: https://forum.image.sc/t/napari-ome-zarr-plugin-slow-navigation/121720

Note: this isn't ready to be merged, because napari doesn't yet support multiple readers for the same file pattern within a single plugin. (It crashes when attempting to open matching files.) However, this *should* work, but just requires the above issues to be fixed in napari, so I'm putting this here as a proof of concept.
