### PR TITLE
Add Release process to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Supported `coordinateTransformations` currently include `identity`, `scale`, `tr
 Contributions are very welcome. Tests can be run with [tox], please ensure
 the coverage at least stays the same before you submit a pull request.
 
+## Release process
+
+To release, use the [GitHub releases page](https://github.com/ome/napari-ome-zarr/releases) to "Draft a new release".
+Create a new Tag, ensuring it starts with `v`, e.g. `v0.10.1`.
+The release notes can be generated automatically and subsequently edited manually if desired.
+
 ## License
 
 Distributed under the terms of the [BSD-3] license,

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ the coverage at least stays the same before you submit a pull request.
 ## Release process
 
 To release, use the [GitHub releases page](https://github.com/ome/napari-ome-zarr/releases) to "Draft a new release".
-Create a new Tag, ensuring it starts with `v`, e.g. `v0.10.1`.
+Create a new Tag, ensuring it starts with `v`, e.g. `v0.10.1`. This will be detected by GitHub actions and trigger
+a deploy of the release to Pypi.
 The release notes can be generated automatically and subsequently edited manually if desired.
 
 ## License


### PR DESCRIPTION
See #166. 

Since we have different release processes on a bunch of repos, it's useful to have some simple steps to follow. Also handy for anyone new to the repo.